### PR TITLE
Adicionando schedule no modelo de Conference e Habilitando o Cors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
+gem 'rack-cors'
 
 gem 'active_model_serializers', '~> 0.10.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8)
@@ -280,6 +282,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.8)
   rspec-rails (~> 6.0.0)
   rubocop

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -38,12 +38,14 @@ class ConferencesController < ApplicationController
     @conference.destroy
   end
 
+  # POST /conferences/1/organize
   def organize
     uploaded_file = params[:file]
 
     if uploaded_file.present?
       lectures = process_file(uploaded_file)
       organized_schedule = Organizer::LectureOrganizerBacktrackService.organize(@conference, lectures)
+      @conference.update(schedule: JSON.parse(organized_schedule.to_json))
       render json: { schedule: organized_schedule }, status: :ok
     else
       render json: { error: 'Arquivo não fornecido' }, status: :bad_request

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  end_date   :datetime         not null
+#  schedule   :jsonb
 #  start_date :datetime         not null
 #  title      :string           not null
 #  created_at :datetime         not null

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -9,7 +9,7 @@
 #  title         :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  track_id      :bigint           not null
+#  track_id      :bigint
 #
 # Indexes
 #
@@ -24,7 +24,8 @@ class Lecture < ApplicationRecord
 
   SESSIONS = %w[morning afternoon].freeze
 
-  validates :title, presence: true
-  validates :duration, :starting_time, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validates :session, presence: true, inclusion: { in: SESSIONS }
+  validates :title, :duration, presence: true
+  validates :duration, :starting_time, numericality: { only_integer: true, greater_than: 0 }
+
+  validates :session, inclusion: { in: SESSIONS, allow_blank: true }
 end

--- a/app/serializers/conference_serializer.rb
+++ b/app/serializers/conference_serializer.rb
@@ -4,11 +4,13 @@
 #
 #  id         :bigint           not null, primary key
 #  end_date   :datetime         not null
+#  schedule   :jsonb
 #  start_date :datetime         not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 class ConferenceSerializer < ActiveModel::Serializer
-  attributes :id, :title, :start_date, :end_date
+  attributes :id, :title, :start_date, :end_date, :schedule
+  has_many :tracks
 end

--- a/app/serializers/lecture_serializer.rb
+++ b/app/serializers/lecture_serializer.rb
@@ -9,7 +9,7 @@
 #  title         :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  track_id      :bigint           not null
+#  track_id      :bigint
 #
 # Indexes
 #

--- a/app/serializers/track_serializer.rb
+++ b/app/serializers/track_serializer.rb
@@ -24,6 +24,7 @@
 class TrackSerializer < ActiveModel::Serializer
   attributes :id, :identifier, :morning_session_start, :morning_session_end, :afternoon_session_start, :afternoon_session_end, :networking_event_start
   has_one :conference
+  has_many :lectures
 
   class SimpleTrackSerializer < ActiveModel::Serializer
     attributes :identifier

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,3 +14,10 @@
 #       methods: [:get, :post, :put, :patch, :delete, :options, :head]
 #   end
 # end
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -18,6 +18,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
-    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+    resource '*', headers: :any, methods: [:get, :post, :patch, :put, :delete]
   end
 end

--- a/db/migrate/20231024001208_add_json_field_to_conferences.rb
+++ b/db/migrate/20231024001208_add_json_field_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddJsonFieldToConferences < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conferences, :schedule, :jsonb
+  end
+end

--- a/db/migrate/20231024011802_remove_null_constraint_from_track_id_in_lectures.rb
+++ b/db/migrate/20231024011802_remove_null_constraint_from_track_id_in_lectures.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromTrackIdInLectures < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :lectures, :track_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_172035) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_24_011802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_172035) do
     t.integer "duration", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "track_id", null: false
+    t.bigint "track_id"
     t.string "session"
     t.integer "starting_time"
     t.index ["track_id"], name: "index_lectures_on_track_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_172035) do
     t.datetime "end_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "schedule"
   end
 
   create_table "lectures", force: :cascade do |t|

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  end_date   :datetime         not null
+#  schedule   :jsonb
 #  start_date :datetime         not null
 #  title      :string           not null
 #  created_at :datetime         not null

--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -9,7 +9,7 @@
 #  title         :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  track_id      :bigint           not null
+#  track_id      :bigint
 #
 # Indexes
 #

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  end_date   :datetime         not null
+#  schedule   :jsonb
 #  start_date :datetime         not null
 #  title      :string           not null
 #  created_at :datetime         not null
@@ -32,6 +33,20 @@ RSpec.describe Conference, type: :model do
     it 'creates tracks after conference creation' do
       conference = build(:conference, start_date: Time.zone.today, end_date: Time.zone.today + 1.day)
       expect { conference.save }.to change(Track, :count).by(conference.days)
+    end
+  end
+
+  describe 'json_data operations' do
+    let(:conference) { create(:conference, schedule: { key1: 'value1' }) }
+
+    it 'allows adding new keys to schedule' do
+      conference.schedule['key2'] = 'value2'
+      conference.save
+      expect(conference.reload.schedule['key2']).to eq('value2')
+    end
+
+    it 'allows reading existing keys from schedule' do
+      expect(conference.schedule['key1']).to eq('value1')
     end
   end
 end

--- a/spec/models/lecture_spec.rb
+++ b/spec/models/lecture_spec.rb
@@ -9,7 +9,7 @@
 #  title         :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  track_id      :bigint           not null
+#  track_id      :bigint
 #
 # Indexes
 #
@@ -27,7 +27,7 @@ RSpec.describe Lecture, type: :model do
   end
 
   describe 'validations' do
-    %i[title duration session starting_time].each { |attribute| it { should validate_presence_of(attribute) } }
+    %i[title duration].each { |attribute| it { should validate_presence_of(attribute) } }
 
     %i[duration starting_time].each do |attribute|
       it {
@@ -36,6 +36,6 @@ RSpec.describe Lecture, type: :model do
       }
     end
 
-    it { should validate_inclusion_of(:session).in_array(Lecture::SESSIONS) }
+    it { should validate_inclusion_of(:session).in_array(Lecture::SESSIONS).allow_blank }
   end
 end

--- a/spec/requests/conferences_spec.rb
+++ b/spec/requests/conferences_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe '/conferences', type: :request do
 
   describe 'POST /conferences/:id/organize' do
     let!(:conference) { create(:conference) }
-    let(:file) { fixture_file_upload('files/lectures_input.txt', 'text/plain') }
+    let(:file) { fixture_file_upload('lectures_input.txt', 'text/plain') }
 
     context 'when the file is provided' do
       before { post "/conferences/#{conference.id}/organize", params: { file: file } }


### PR DESCRIPTION
Este PR traz três atualizações principais:

1. **Agenda JSON em Conferência**: adiciona um snapshot do melhor agendamento ótimo na Conference
2. **Flexibilidade em Palestra**: Remove a exigência de que cada `Palestra` deve pertencer a uma `Track`.
3. **Suporte a CORS**: Habilita CORS para melhor integração com o frontend.

![image](https://github.com/thitcc/palestrinhas-api/assets/30185790/5d867f87-5c10-44f7-aedb-ffcd58438c5b)
